### PR TITLE
Faster atmosphere lut

### DIFF
--- a/src/clj/sfsim/atmosphere.clj
+++ b/src/clj/sfsim/atmosphere.clj
@@ -117,7 +117,12 @@
   {:malli/schema [:function [:=> [:cat atmosphere [:vector scatter] N fvec3 fvec3] fvec3]
                   [:=> [:cat atmosphere [:vector scatter] N fvec3 fvec3 :boolean] fvec3]]}
   ([planet scatter steps x x0]
-   (let [overall-extinction (fn overall-extinction [point] (apply add (mapv #(extinction % (height planet point)) scatter)))]
+   (let [overall-extinction (if (= (count scatter) 1)
+                              (let [[u] scatter]
+                                (fn overall-extinction [point] (extinction u (height planet point))))
+                              (let [[u v] scatter]
+                                (fn overall-extinction [point] (add (extinction u (height planet point))
+                                                                   (extinction v (height planet point))))))]
      (-> (integral-ray #:sfsim.ray{:origin x :direction (sub x0 x)} steps 1.0 overall-extinction) sub fv/exp)))
   ([planet scatter steps x v above-horizon]
    (let [intersection (if above-horizon atmosphere-intersection surface-intersection)]

--- a/src/clj/sfsim/atmosphere.clj
+++ b/src/clj/sfsim/atmosphere.clj
@@ -50,7 +50,7 @@
 (defn extinction
   "Compute Mie or Rayleigh extinction for given atmosphere and height"
   {:malli/schema [:=> [:cat scatter :double] fvec3]}
-  [scattering-type height]
+  [scattering-type ^double height]
   (div (scattering scattering-type height) (or (::scatter-quotient scattering-type) 1.0)))
 
 

--- a/src/clj/sfsim/ray.clj
+++ b/src/clj/sfsim/ray.clj
@@ -7,20 +7,29 @@
 (ns sfsim.ray
   "Functions dealing with rays"
   (:require
-    [fastmath.vector :refer (add mult mag)]
+    [fastmath.vector :refer (add mult mag vec3)]
     [malli.core :as m]
     [sfsim.util :refer (N)]))
 
 
 (def ray (m/schema [:map [::origin [:vector :double]] [::direction [:vector :double]]]))
 
+(set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
 
 (defn integral-ray
   "Integrate given function over a ray in 3D space"
   {:malli/schema [:=> [:cat ray N :double [:=> [:cat [:vector :double]] :some]] :some]}
-  [{::keys [origin direction]} steps distance fun]
+  [{::keys [origin direction]} ^long steps ^double distance fun]
   (let [stepsize      (/ distance steps)
-        samples       (mapv #(* (+ 0.5 %) stepsize) (range steps))
+        samples       (->Eduction (map (fn ^double [^long n] (* (+ 0.5 n) stepsize))) (range steps))
         interpolate   (fn interpolate [s] (add origin (mult direction s)))
-        direction-len (mag direction)]
-    (reduce add (mapv #(-> % interpolate fun (mult (* stepsize direction-len))) samples))))
+        direction-len (mag direction)
+        a (* stepsize direction-len)]
+    (reduce
+     add
+     (vec3 0 0 0)
+     (->Eduction (map #(-> % interpolate fun (mult a))) samples))))
+
+(set! *warn-on-reflection* false)
+(set! *unchecked-math* false)

--- a/test/clj/sfsim/t_ray.clj
+++ b/test/clj/sfsim/t_ray.clj
@@ -6,7 +6,7 @@
 
 (ns sfsim.t-ray
   (:require
-    [fastmath.vector :refer (vec2 vec3)]
+    [fastmath.vector :refer (vec3)]
     [malli.dev.pretty :as pretty]
     [malli.instrument :as mi]
     [midje.sweet :refer :all]
@@ -19,11 +19,11 @@
 
 
 (facts "Integrate over a ray"
-       (integral-ray #:sfsim.ray{:origin (vec3 2 3 5) :direction (vec3 1 0 0)} 10 0.0 (fn [x] (vec2 2 2)))
-       => (roughly-vector (vec2 0 0) 1e-6)
-       (integral-ray #:sfsim.ray{:origin (vec3 2 3 5) :direction (vec3 1 0 0)} 10 3.0 (fn [x] (vec2 2 2)))
-       => (roughly-vector (vec2 6 6) 1e-6)
-       (integral-ray #:sfsim.ray{:origin (vec3 2 3 5) :direction (vec3 1 0 0)} 10 3.0 (fn [x] (vec2 (x 0) (x 0))))
-       => (roughly-vector (vec2 10.5 10.5) 1e-6)
-       (integral-ray #:sfsim.ray{:origin (vec3 2 3 5) :direction (vec3 2 0 0)} 10 1.5 (fn [x] (vec2 (x 0) (x 0))))
-       => (roughly-vector (vec2 10.5 10.5) 1e-6))
+       (integral-ray #:sfsim.ray{:origin (vec3 2 3 5) :direction (vec3 1 0 0)} 10 0.0 (fn [x] (vec3 2 2 0)))
+       => (roughly-vector (vec3 0 0 0) 1e-6)
+       (integral-ray #:sfsim.ray{:origin (vec3 2 3 5) :direction (vec3 1 0 0)} 10 3.0 (fn [x] (vec3 2 2 0)))
+       => (roughly-vector (vec3 6 6 0) 1e-6)
+       (integral-ray #:sfsim.ray{:origin (vec3 2 3 5) :direction (vec3 1 0 0)} 10 3.0 (fn [x] (vec3 (x 0) (x 0) 0)))
+       => (roughly-vector (vec3 10.5 10.5 0) 1e-6)
+       (integral-ray #:sfsim.ray{:origin (vec3 2 3 5) :direction (vec3 2 0 0)} 10 1.5 (fn [x] (vec3 (x 0) (x 0) 0)))
+       => (roughly-vector (vec3 10.5 10.5 0) 1e-6))


### PR DESCRIPTION
Hello
I noticed in reading your blog post you mentioned generating the atmospheric LUTs was CPU intensive, and decided to poke at the code to see if there are any easy gains to be had.
I think I managed to speed it up by about 60-70% with a small number of changes.
These techniques could perhaps be applied in other areas of the code but I focused my experiment there.

I had to adapt the test for integral-ray but I saw no instances where it receives anything besides a function returning a vec3