### PR TITLE
Naive speedup of quaternions

### DIFF
--- a/src/clj/sfsim/quaternion.clj
+++ b/src/clj/sfsim/quaternion.clj
@@ -88,10 +88,9 @@
 (defn norm2
   "Compute square of norm of quaternion"
   ^double [^Quaternion q]
-  (c/+ (sqr (.real q))
-       (sqr (.imag q))
-       (sqr (.jmag q))
-       (sqr (.kmag q))))
+  (c/+
+   (c/+ (sqr (.real q)) (sqr (.imag q)))
+   (c/+ (sqr (.jmag q)) (sqr (.kmag q)))))
 
 
 (defn norm

--- a/src/clj/sfsim/quaternion.clj
+++ b/src/clj/sfsim/quaternion.clj
@@ -158,8 +158,7 @@
 (defn rotation
   "Generate quaternion to represent rotation"
   ^Quaternion [^double theta ^Vec3 v]
-  (let [scale (c/* theta 0.5)]
-    (exp (vector->quaternion (mult v scale)))))
+  (exp (vector->quaternion (mult v (c/* theta 0.5)))))
 
 
 (defn rotate-vector

--- a/src/clj/sfsim/quaternion.clj
+++ b/src/clj/sfsim/quaternion.clj
@@ -8,22 +8,26 @@
   "Complex algebra implementation."
   (:refer-clojure :exclude [+ - *])
   (:require
-    [clojure.core :as c]
-    [clojure.math :refer (cos sqrt) :as m]
-    [fastmath.vector :refer (vec3 mag mult cross dot)]
-    [malli.core :as mc]
-    [sfsim.util :refer (sinc sqr)])
+   [clojure.core :as c]
+   [clojure.math :refer (cos sqrt) :as m]
+   [fastmath.vector :refer (mag mult cross dot)]
+   [malli.core :as mc]
+   [sfsim.util :refer (sinc sqr)])
   (:import
-    [fastmath.vector
-     Vec3]))
+   [fastmath.vector
+    Vec3]))
 
 
-(set! *unchecked-math* :warn-on-boxed)
+(set! *unchecked-math* true)
 (set! *warn-on-reflection* true)
 
 
 (defrecord Quaternion
-  [^double real ^double imag ^double jmag ^double kmag])
+    [^double real ^double imag ^double jmag ^double kmag])
+
+(defn ->Quaternion
+  ^Quaternion [^double real ^double imag ^double jmag ^double kmag]
+  (Quaternion. real imag jmag kmag))
 
 
 (def fvec3 (mc/schema [:tuple :double :double :double]))
@@ -34,60 +38,60 @@
   "Add two quaternions"
   {:malli/schema [:=> [:cat quaternion quaternion] quaternion]}
   ^Quaternion [^Quaternion p ^Quaternion q]
-  (->Quaternion (c/+ ^double (:real p) ^double (:real q))
-                (c/+ ^double (:imag p) ^double (:imag q))
-                (c/+ ^double (:jmag p) ^double (:jmag q))
-                (c/+ ^double (:kmag p) ^double (:kmag q))))
+  (Quaternion. (c/+ (.real p) (.real q))
+               (c/+ (.imag p) (.imag q))
+               (c/+ (.jmag p) (.jmag q))
+               (c/+ (.kmag p) (.kmag q))))
 
 
 (defn -
   "Negate quaternion or subtract two quaternions"
   {:malli/schema [:=> [:cat quaternion [:? quaternion]] quaternion]}
   ([^Quaternion p]
-   (->Quaternion (c/- ^double (:real p)) (c/- ^double (:imag p)) (c/- ^double (:jmag p)) (c/- ^double (:kmag p))))
+   (Quaternion. (c/- (.real p)) (c/- (.imag p)) (c/- (.jmag p)) (c/- (.kmag p))))
   ([^Quaternion p ^Quaternion q]
-   (->Quaternion (c/- ^double (:real p) ^double (:real q))
-                 (c/- ^double (:imag p) ^double (:imag q))
-                 (c/- ^double (:jmag p) ^double (:jmag q))
-                 (c/- ^double (:kmag p) ^double (:kmag q)))))
+   (Quaternion. (c/- (.real p) (.real q))
+                (c/- (.imag p) (.imag q))
+                (c/- (.jmag p) (.jmag q))
+                (c/- (.kmag p) (.kmag q)))))
 
 
 (defn *
   "Multiply two quaternions"
   {:malli/schema [:=> [:cat quaternion quaternion] quaternion]}
   ^Quaternion [^Quaternion p ^Quaternion q]
-  (let [p-real (:real p)
-        p-imag (:imag p)
-        p-jmag (:jmag p)
-        p-kmag (:kmag p)
-        q-real (:real q)
-        q-imag (:imag q)
-        q-jmag (:jmag q)
-        q-kmag (:kmag q)]
-    (->Quaternion
-      (c/- (c/* ^double p-real ^double q-real) (c/* ^double p-imag ^double q-imag)
-           (c/* ^double p-jmag ^double q-jmag) (c/* ^double p-kmag ^double q-kmag))
-      (c/- (c/+ (c/* ^double p-real ^double q-imag) (c/* ^double p-imag ^double q-real)
-                (c/* ^double p-jmag ^double q-kmag)) (c/* ^double p-kmag ^double q-jmag))
-      (c/+ (c/- (c/* ^double p-real ^double q-jmag) (c/* ^double p-imag ^double q-kmag))
-           (c/* ^double p-jmag ^double q-real) (c/* ^double p-kmag ^double q-imag))
-      (c/+ (c/- (c/+ (c/* ^double p-real ^double q-kmag) (c/* ^double p-imag ^double q-jmag))
-                (c/* ^double p-jmag ^double q-imag)) (c/* ^double p-kmag ^double q-real)))))
+  (let [p-real (.real p)
+        p-imag (.imag p)
+        p-jmag (.jmag p)
+        p-kmag (.kmag p)
+        q-real (.real q)
+        q-imag (.imag q)
+        q-jmag (.jmag q)
+        q-kmag (.kmag q)]
+    (Quaternion.
+     (c/- (c/* p-real q-real) (c/* p-imag q-imag)
+          (c/* p-jmag q-jmag) (c/* p-kmag q-kmag))
+     (c/- (c/+ (c/* p-real q-imag) (c/* p-imag q-real)
+               (c/* p-jmag q-kmag)) (c/* p-kmag q-jmag))
+     (c/+ (c/- (c/* p-real q-jmag) (c/* p-imag q-kmag))
+          (c/* p-jmag q-real) (c/* p-kmag q-imag))
+     (c/+ (c/- (c/+ (c/* p-real q-kmag) (c/* p-imag q-jmag))
+               (c/* p-jmag q-imag)) (c/* p-kmag q-real)))))
 
 
 (defn scale
   "Multiply quaternion with real number"
   ^Quaternion [^Quaternion q ^double s]
-  (->Quaternion (c/* ^double (:real q) s) (c/* ^double (:imag q) s) (c/* ^double (:jmag q) s) (c/* ^double (:kmag q) s)))
+  (Quaternion. (c/* (.real q) s) (c/* (.imag q) s) (c/* (.jmag q) s) (c/* (.kmag q) s)))
 
 
 (defn norm2
   "Compute square of norm of quaternion"
   ^double [^Quaternion q]
-  (c/+ (sqr (:real q))
-       (sqr (:imag q))
-       (sqr (:jmag q))
-       (sqr (:kmag q))))
+  (c/+ (sqr (.real q))
+       (sqr (.imag q))
+       (sqr (.jmag q))
+       (sqr (.kmag q))))
 
 
 (defn norm
@@ -100,18 +104,14 @@
   "Normalize quaternion to create unit quaternion"
   {:malli/schema [:=> [:cat quaternion] quaternion]}
   ^Quaternion [^Quaternion q]
-  (let [factor (/ 1.0 (norm q))]
-    (->Quaternion (c/* ^double (:real q) factor)
-                  (c/* ^double (:imag q) factor)
-                  (c/* ^double (:jmag q) factor)
-                  (c/* ^double (:kmag q) factor))))
+  (scale q (/ 1.0 (norm q))))
 
 
 (defn conjugate
   "Return conjugate of quaternion"
   {:malli/schema [:=> [:cat quaternion] quaternion]}
   ^Quaternion[^Quaternion q]
-  (->Quaternion (:real q) (c/- ^double (:imag q)) (c/- ^double (:jmag q)) (c/- ^double (:kmag q))))
+  (Quaternion. (.real q) (c/- (.imag q)) (c/- (.jmag q)) (c/- (.kmag q))))
 
 
 (defn inverse
@@ -119,38 +119,41 @@
   {:malli/schema [:=> [:cat quaternion] quaternion]}
   ^Quaternion[^Quaternion q]
   (let [factor (/ 1.0 (norm2 q))]
-    (->Quaternion (c/* ^double (:real q) factor)
-                  (c/* ^double (c/- ^double (:imag q)) factor)
-                  (c/* ^double (c/- ^double (:jmag q)) factor)
-                  (c/* ^double (c/- ^double (:kmag q)) factor))))
+    (Quaternion. (c/* (.real q) factor)
+                 (c/* (c/- (.imag q)) factor)
+                 (c/* (c/- (.jmag q)) factor)
+                 (c/* (c/- (.kmag q)) factor))))
 
 
 (defn vector->quaternion
   "Convert 3D vector to quaternion"
   {:malli/schema [:=> [:cat fvec3] quaternion]}
   [v]
-  (apply ->Quaternion 0.0 v))
+  (if (instance? Vec3 v)
+    (let [v ^Vec3 v]
+      (Quaternion. 0.0 (.x v) (.y v) (.z v)))
+    (Quaternion. 0.0 (nth v 0) (nth v 1) (nth v 2))))
 
 
 (defn quaternion->vector
   "Convert quaternion to 3D vector"
   {:malli/schema [:=> [:cat quaternion] fvec3]}
-  [q]
-  (vec3 (:imag q) (:jmag q) (:kmag q)))
+  [^Quaternion q]
+  (Vec3. (.imag q) (.jmag q) (.kmag q)))
 
 
 (defn exp
   "Exponentiation of quaternion"
   {:malli/schema [:=> [:cat quaternion] quaternion]}
   ^Quaternion [^Quaternion q]
-  (let [scale      (m/exp (:real q))
-        rotation   (mag (quaternion->vector q))
-        cos-scale  (c/* scale (cos rotation))
+  (let [scale   (m/exp (.real q))
+        rotation  (mag (quaternion->vector q))
+        cos-scale (c/* scale (cos rotation))
         sinc-scale (c/* scale (sinc rotation))]
-    (->Quaternion cos-scale
-                  (c/* sinc-scale ^double (:imag q))
-                  (c/* sinc-scale ^double (:jmag q))
-                  (c/* sinc-scale ^double (:kmag q)))))
+    (Quaternion. cos-scale
+                 (c/* sinc-scale (.imag q))
+                 (c/* sinc-scale (.jmag q))
+                 (c/* sinc-scale (.kmag q)))))
 
 
 (defn rotation
@@ -170,10 +173,10 @@
 (defn vector-to-vector-rotation
   "Create quaternion for rotating u to v"
   {:malli/schema [:=> [:cat fvec3 fvec3] quaternion]}
-  [u v]
+  ^Quaternion [u v]
   (let [axis (cross u v)
         w    (c/+ (c/* (mag u) (mag v)) (dot u v))]
-    (normalize (->Quaternion w (axis 0) (axis 1) (axis 2)))))
+    (normalize (Quaternion. w (nth axis 0) (nth axis 1) (nth axis 2)))))
 
 
 (set! *warn-on-reflection* false)


### PR DESCRIPTION
Since we brought it up on #152, this PR removes all boxing along quaternion math.
Tests pass, no reflection warnings.
Hope I haven't missed anything.